### PR TITLE
fixed typo! (from keyowrds to keywords)

### DIFF
--- a/C11.py
+++ b/C11.py
@@ -432,7 +432,7 @@ syntax = {
             'patterns':
             [
                 {
-                    'name' : 'entity.other.macro.keyowrds.c.11',
+                    'name' : 'entity.other.macro.keywords.c.11',
                     'match': r'^\s*(#)\s*((include\s+(<(.+)>|"(.+)"))|'
                              r'line|error|pragma|'
                              r'(un|ifn?)def|else|endif)',

--- a/langs/C11.tmLanguage
+++ b/langs/C11.tmLanguage
@@ -382,7 +382,7 @@
 					<key>match</key>
 					<string>^\s*(#)\s*((include\s+(&lt;(.+)&gt;|"(.+)"))|line|error|pragma|(un|ifn?)def|else|endif)</string>
 					<key>name</key>
-					<string>entity.other.macro.keyowrds.c.11</string>
+					<string>entity.other.macro.keywords.c.11</string>
 				</dict>
 				<dict>
 					<key>begin</key>


### PR DESCRIPTION
While trying to use this to fix my syntax highlighting, I found a typo.

So I went through all the trouble of getting all the related tools (python3, yaml, cutils, tmtools, etc...), and fixed it! :)